### PR TITLE
feat: Remove media items from map cells with single request

### DIFF
--- a/apps/cli-client/pyproject.toml
+++ b/apps/cli-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "photos_drive"
-version = "9.2.0"
+version = "9.2.1"
 description = ""
 authors = [{ name = "Emilio Kartono", email = "e.kartonoe@gmail.com" }]
 packages = [{include = "photos_drive"}]

--- a/apps/cli-client/src/photos_drive/backup/backup_photos.py
+++ b/apps/cli-client/src/photos_drive/backup/backup_photos.py
@@ -196,9 +196,10 @@ class PhotosBackup:
                 queue.append(child_diff_tree_node)
 
         # Step 6: Delete the media items marked for deletion
-        self.__media_items_repo.delete_many_media_items(
-            [media_item.id for media_item in total_media_items_to_delete]
-        )
+        media_item_ids_to_delete = [
+            media_item.id for media_item in total_media_items_to_delete
+        ]
+        self.__media_items_repo.delete_many_media_items(media_item_ids_to_delete)
 
         # Step 7: Delete albums with no child albums and no media items
         total_num_albums_deleted = 0
@@ -208,8 +209,7 @@ class PhotosBackup:
                 total_num_albums_deleted += self.__albums_pruner.prune_album(album_id)
 
         # Step 8: Delete items from the maps
-        for media_item in total_media_items_to_delete:
-            self.__map_cells_repo.remove_media_item(media_item.id)
+        self.__map_cells_repo.remove_many_media_items(media_item_ids_to_delete)
 
         # Step 9: Add items to the maps repo
         for media_item in add_diffs_to_media_item.values():

--- a/apps/cli-client/src/photos_drive/shared/features/maps/repository/base.py
+++ b/apps/cli-client/src/photos_drive/shared/features/maps/repository/base.py
@@ -43,3 +43,12 @@ class MapCellsRepository(ABC):
         Args:
             media_item_id (MediaItemId): The ID of the media item to remove
         '''
+
+    @abstractmethod
+    def remove_many_media_items(self, media_item_ids: list[MediaItemId]):
+        '''
+        Removes a list of media items from the cells repository.
+
+        Args:
+            media_item_ids (list[MediaItemId): The IDs of the media items to remove
+        '''

--- a/apps/cli-client/src/photos_drive/shared/features/maps/repository/mongodb.py
+++ b/apps/cli-client/src/photos_drive/shared/features/maps/repository/mongodb.py
@@ -89,3 +89,19 @@ class MongoDBMapCellsRepository(MapCellsRepository):
             },
             session=session,
         )
+
+    def remove_many_media_items(self, media_item_ids: list[MediaItemId]):
+        if len(media_item_ids) == 0:
+            return
+
+        session = self._mongodb_sessions_provider.get_session_for_client_id(
+            self._client_id,
+        )
+        self._mongodb_client["photos_drive"]["map_cells"].delete_many(
+            filter={
+                "media_item_id": {
+                    "$in": [media_item_id_to_string(id) for id in media_item_ids]
+                },
+            },
+            session=session,
+        )

--- a/apps/cli-client/src/photos_drive/shared/features/maps/repository/union.py
+++ b/apps/cli-client/src/photos_drive/shared/features/maps/repository/union.py
@@ -49,6 +49,10 @@ class UnionMapCellsRepository(MapCellsRepository):
         for repo in self._repositories:
             repo.remove_media_item(media_item_id)
 
+    def remove_many_media_items(self, media_item_ids: list[MediaItemId]):
+        for repo in self._repositories:
+            repo.remove_many_media_items(media_item_ids)
+
 
 def create_union_map_cells_repository_from_db_clients(
     mongodb_clients_repo: MongoDBClientsRepository,

--- a/apps/cli-client/tests/shared/features/maps/repository/test_mongodb.py
+++ b/apps/cli-client/tests/shared/features/maps/repository/test_mongodb.py
@@ -120,7 +120,7 @@ class TestMongoDBMapCellsRepository(unittest.TestCase):
         # Assert that all items have been removed
         for mid in ids_to_remove:
             deleted_media = self.mongo_client["photos_drive"]["map_cells"].find_one(
-                {"_id": mid.object_id}
+                {"media_item_id": media_item_id_to_string(mid)}
             )
             self.assertIsNone(deleted_media)
 

--- a/apps/cli-client/tests/shared/features/maps/repository/test_mongodb.py
+++ b/apps/cli-client/tests/shared/features/maps/repository/test_mongodb.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from datetime import datetime
 import unittest
 
@@ -101,3 +102,27 @@ class TestMongoDBMapCellsRepository(unittest.TestCase):
         # Check that cells were deleted
         deleted = list(self.mongo_client["photos_drive"]["map_cells"].find())
         self.assertEqual(len(deleted), 0)
+
+    def test_remove_many_media_items(self):
+        ids_to_remove = [
+            MediaItemId(MONGO_CLIENT_ID, ObjectId()),
+            MediaItemId(MONGO_CLIENT_ID, ObjectId()),
+        ]
+
+        # Insert mock media items into the mock database
+        for mid in ids_to_remove:
+            media_item = replace(MEDIA_ITEM, id=mid)
+            self.repo.add_media_item(media_item)
+
+        # Test deletion of multiple items
+        self.repo.remove_many_media_items(ids_to_remove)
+
+        # Assert that all items have been removed
+        for mid in ids_to_remove:
+            deleted_media = self.mongo_client["photos_drive"]["map_cells"].find_one(
+                {"_id": mid.object_id}
+            )
+            self.assertIsNone(deleted_media)
+
+    def test_remove_many_media_items_with_no_documents_throws_no_errors(self):
+        self.repo.remove_many_media_items([])

--- a/apps/cli-client/tests/shared/features/maps/repository/test_union.py
+++ b/apps/cli-client/tests/shared/features/maps/repository/test_union.py
@@ -55,3 +55,11 @@ class TestUnionMapCellsRepository(unittest.TestCase):
 
         self.repo1.remove_media_item.assert_called_once_with(mid)
         self.repo2.remove_media_item.assert_called_once_with(mid)
+
+    def test_remove_many_media_items__delegates_to_all_repos(self):
+        id_1 = MediaItemId(self.repo1.get_client_id(), ObjectId())
+        id_2 = MediaItemId(self.repo2.get_client_id(), ObjectId())
+        self.union_repo.remove_many_media_items([id_1, id_2])
+
+        self.repo1.remove_many_media_items.assert_called_once_with([id_1, id_2])
+        self.repo2.remove_many_media_items.assert_called_once_with([id_1, id_2])

--- a/apps/cli-client/uv.lock
+++ b/apps/cli-client/uv.lock
@@ -2174,7 +2174,7 @@ wheels = [
 
 [[package]]
 name = "photos-drive"
-version = "9.2.0"
+version = "9.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "backoff" },

--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -24,7 +24,7 @@ The system consists of three main applications:
 
 ## Data Stores
 
-The entire system uses different data stores to store different types of data. Refer to [this guide](./docs/database_schema.md) for more info on their schemas. In essence, there are four types of data stores in the system:
+The entire system uses different data stores to store different types of data. Refer to [this guide](./docs/internal/database_schema.md) for more info on their schemas. In essence, there are four types of data stores in the system:
 
 ### 1. Config Store
 


### PR DESCRIPTION
This PR adds support for removing multiple media items from a MapCellsRepository with a single request

This follows a similar pattern as MediaItemsRepository.delete_many_media_items

Also updates a documentation link